### PR TITLE
RMET-1442 Social Login Plugin - Android Apple Sign In use code instead of id to validate token

### DIFF
--- a/src/android/com/outsystems/plugins/sociallogins/OAuthActivity.kt
+++ b/src/android/com/outsystems/plugins/sociallogins/OAuthActivity.kt
@@ -60,6 +60,7 @@ class OAuthActivity : Activity() {
         val picture = intent?.data?.getQueryParameter("picture")
         val provider = intent?.data?.getQueryParameter("provider")
         val state = intent?.data?.getQueryParameter("state")
+        val code = intent?.data?.getQueryParameter("code")
         val errorCode = intent?.data?.getQueryParameter("errorCode")?.toInt()
 
         val resultBundle = Bundle()
@@ -70,6 +71,7 @@ class OAuthActivity : Activity() {
         resultBundle.putString("email", email)
         resultBundle.putString("picture", picture)
         resultBundle.putString("state", state)
+        resultBundle.putString("code", code)
         errorCode?.let { resultBundle.putInt("errorCode", it) }
 
         val resultIntent = Intent()

--- a/src/android/com/outsystems/plugins/sociallogins/SocialLoginsAppleController.kt
+++ b/src/android/com/outsystems/plugins/sociallogins/SocialLoginsAppleController.kt
@@ -45,17 +45,18 @@ class SocialLoginsAppleController(private val appleTokenValidation: AppleHelperI
                     val firstName = returnBundle.getString("firstName")
                     val lastName = returnBundle.getString("lastName")
                     val email = returnBundle.getString("email") ?: ""
+                    val code = returnBundle.getString("code")
 
                     if (id.isNullOrEmpty()) {
                         onError(SocialLoginError.APPLE_MISSING_USER_ID)
                     } else if (token.isNullOrEmpty()) {
                         onError(SocialLoginError.APPLE_MISSING_ACCESS_TOKEN_ERROR)
-                    } else if (state.isNullOrEmpty()) {
+                    } else if (state.isNullOrEmpty() || code.isNullOrEmpty()) {
                         onError(SocialLoginError.APPLE_SIGN_IN_GENERAL_ERROR)
                     } else {
 
                         if (!state.isNullOrEmpty()) {
-                            appleTokenValidation.validateToken(id, state, this.redirectUri,
+                            appleTokenValidation.validateToken(code, state, this.redirectUri,
                                 {
                                     onSuccess(
                                         UserInfo(


### PR DESCRIPTION
## Description
This was working before because we were sending the code in the id.

## Context
<!--- Why is this change required? What problem does it solve? -->
Solved as part of this Jira story: https://outsystemsrd.atlassian.net/browse/RMET-1422

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
Tested in MABS and using a real device. Builds working and sign in working.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly