### PR TITLE
RPM-3153 ::: Rename AppDelegate Swizzled Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,36 +8,39 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
-## [Released]
+### 2022-10-12
+- Fix: [iOS] Rename the swizzled `appDelegate:didFinishLaunchingWithOptions:` method to something unique (https://outsystemsrd.atlassian.net/jira/software/c/projects/RMET/boards/893?selectedIssue=RPM-3153).
 
-## Version 1.0.0 (11-04-2022)
+## Version 1.0.1 (2022-06-29)
 
-## 2022-06-29
+### 2022-06-29
 - Fix: Removed hook that adds swift support and added the plugin as dependecy. (https://outsystemsrd.atlassian.net/browse/RMET-1680)
 
-## 2022-04-05
+## Version 1.0.0 (2022-04-11)
+
+### 2022-04-05
 - Hiding blank OAuthActivity called for Apple and LinkedIn login (https://outsystemsrd.atlassian.net/browse/RMET-1536)
 - Removed suplicated files and added .arr dependencies (https://outsystemsrd.atlassian.net/browse/RMET-1476)
 
-## 2022-04-01
+### 2022-04-01
 - Fixing if google email is empty or null (https://outsystemsrd.atlassian.net/browse/RMET-1422)
 
-## 2022-03-28
+### 2022-03-28
 - Implementation of LinkedIn Sign In on Android (https://outsystemsrd.atlassian.net/browse/RMET-1450)
 
-## 2022-03-25
+### 2022-03-25
 - Implementation of LinkedIn Sign In on iOS (https://outsystemsrd.atlassian.net/browse/RMET-1449)
 
-## 2022-03-16
+### 2022-03-16
 - Implementation of Google Sign In on Android (https://outsystemsrd.atlassian.net/browse/RMET-1246)
 - Implementation of Facebook Sign In on iOS (https://outsystemsrd.atlassian.net/browse/RMET-1420) & (https://outsystemsrd.atlassian.net/browse/RMET-1421)
 
-## 2022-03-03
+### 2022-03-03
 - Implementation of Apple Sign In on iOS (https://outsystemsrd.atlassian.net/browse/RMET-1405)
 - Apple Sign In implementation for Android (https://outsystemsrd.atlassian.net/browse/RMET-1406)
 
-## 2021-11-30
+### 2021-11-30
 - PoC Implementation of the Google Sign In for Android (https://outsystemsrd.atlassian.net/browse/RMET-1152)
 
-## 2021-11-29
+### 2021-11-29
 - PoC Implementation of the Apple Sign In for Android (https://outsystemsrd.atlassian.net/browse/RMET-1213)

--- a/src/ios/AppDelegate+OSSocialLogins.m
+++ b/src/ios/AppDelegate+OSSocialLogins.m
@@ -7,12 +7,12 @@
 
 + (void)load {
     Method original = class_getInstanceMethod(self, @selector(application:didFinishLaunchingWithOptions:));
-    Method swizzled = class_getInstanceMethod(self, @selector(application:swizzledDidFinishLaunchingWithOptions:));
+    Method swizzled = class_getInstanceMethod(self, @selector(application:socialLoginsPluginDidFinishLaunchingWithOptions:));
     method_exchangeImplementations(original, swizzled);
 }
 
-- (BOOL)application:(UIApplication *)application swizzledDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [self application:application swizzledDidFinishLaunchingWithOptions:launchOptions];
+- (BOOL)application:(UIApplication *)application socialLoginsPluginDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    [self application:application socialLoginsPluginDidFinishLaunchingWithOptions:launchOptions];
     
     (void)[SocialLoginsApplicationDelegate.shared application:application didFinishLaunchingWithOptions:launchOptions];
     


### PR DESCRIPTION
## Description
Rename the swizzled `appDelegate:didFinishLaunchingWithOptions:` method on the `AppDelegate` extension to something unique. This is required to avoid incompatibility with other plugins.

## Context
https://outsystemsrd.atlassian.net/browse/RPM-3153

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
