### PR TITLE
iOS ::: Fix Hook for Provider Configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2022-10-18
+- Fix: [iOS] Update hook so that providers can be individually configured and not all are required for the plugin to work.
+- Fix: [iOS] Improve error handling, so that more detailed messages can be thrown on build process.
+
 ### 2022-10-12
 - Fix: [iOS] Rename the swizzled `appDelegate:didFinishLaunchingWithOptions:` method to something unique (https://outsystemsrd.atlassian.net/jira/software/c/projects/RMET/boards/893?selectedIssue=RPM-3153).
 

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -1,6 +1,7 @@
 const et = require('elementtree');
 const path = require('path');
 const fs = require('fs');
+const plist = require('plist');
 const { ConfigParser } = require('cordova-common');
 const { Console } = require('console');
 
@@ -21,59 +22,104 @@ module.exports = function (context) {
     var appNameParser = new ConfigParser(appNamePath);
     var appName = appNameParser.name();
 
+    let platformPath = path.join(projectRoot, 'platforms/ios');
+
     //read json config file                         platforms/ios/www/jsonConfig
     var jsonConfig = "";
     try {
-        jsonConfig = path.join(projectRoot, 'platforms/ios/www/json-config/SocialLoginsConfigurations.json');
-        var jsonConfigFile = fs.readFileSync(jsonConfig).toString();
+        jsonConfig = path.join(projectRoot, 'www/json-config/SocialLoginsConfigurations.json');
+        var jsonConfigFile = fs.readFileSync(jsonConfig, 'utf8');
         var jsonParsed = JSON.parse(jsonConfigFile);
-    
-        jsonParsed.app_configurations.forEach(function(configItem) {
-            if ((configItem.provider_id == ProvidersEnum.google) && (configItem.application_type_id == ApplicationTypeEnum.ios)) {
-                google_url_scheme = configItem.url_scheme
-            } else if ((configItem.provider_id == ProvidersEnum.facebook) && (configItem.application_type_id == ApplicationTypeEnum.ios)) {
-                facebook_client_appId = configItem.client_id;
-                facebook_client_token = configItem.client_token;
-            }
-        });
-        deeplink_url_scheme = jsonParsed.app_deeplink.url_scheme;
     } catch {
         throw new Error("Missing configuration file or error trying to obtain the configuration.");
     }
 
-    //Change info.plist
-    var infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
-    var infoPlistFile = fs.readFileSync(infoPlistPath).toString();
-    var etreeInfoPlist = et.parse(infoPlistFile);
-    var infoPlistTags = etreeInfoPlist.findall('./dict/array/dict/array/string');
+    const iOSConfigArray = jsonParsed.app_configurations.filter(configItem => configItem.application_type_id == ApplicationTypeEnum.ios);
+    const errorMap = new Map();
+
+    iOSConfigArray.forEach(function(configItem) {
+        if (configItem.provider_id == ProvidersEnum.google) {
+            var googleErrorArray = [];
+
+            if (configItem.url_scheme != null && configItem.url_scheme !== "") {
+                google_url_scheme = configItem.url_scheme;
+            } else {
+                googleErrorArray.push('URL Scheme');
+            }
+
+            if (googleErrorArray.length > 0) {
+                errorMap['Google'] = googleErrorArray;
+            }
+        } else if (configItem.provider_id == ProvidersEnum.facebook) {
+            var facebookErrorArray = [];
+
+            if (configItem.client_id != null && configItem.client_id !== "") {
+                console.log(facebook_client_appId);
+                facebook_client_appId = configItem.client_id;
+            } else {
+                facebookErrorArray.push('Client ID');
+            }
+
+            if (configItem.client_token != null && configItem.client_token !== "") {
+                console.log(facebook_client_token);
+                facebook_client_token = configItem.client_token;
+            } else {
+                facebookErrorArray.push('Client Token');
+            }
+
+            if (facebookErrorArray.length > 0) {
+                errorMap['Facebook'] = facebookErrorArray;
+            }
+        }
+    });
+
+    if (jsonParsed.app_deeplink.url_scheme != null && jsonParsed.app_deeplink.url_scheme !== "") {
+        deeplink_url_scheme = jsonParsed.app_deeplink.url_scheme;
+    } else {
+        errorMap['General'] = ['URL Scheme'];
+    }
+
+    if (Object.getOwnPropertyNames(errorMap).length > 0) {
+        var errorMessage = 'Configuration is missing the following fields: ';        
+
+        for (const [key, value] of Object.entries(errorMap)) {
+            errorMessage += '\n - On ' + key + ': ' + value + '.';
+        }
+        throw new Error(errorMessage);
+    }
     
-    for (var i = 0; i < infoPlistTags.length; i++) {
-        if (infoPlistTags[i].text.includes("GOOGLE_CLIENT_ID")) {
-            infoPlistTags[i].text = infoPlistTags[i].text.replace('GOOGLE_CLIENT_ID', google_url_scheme);
-        }
+    //Change info.plist
+    var infoPlistPath = path.join(platformPath, appName + '/'+ appName +'-info.plist');
+    var infoPlistFile = fs.readFileSync(infoPlistPath, 'utf8');
+    var infoPlist = plist.parse(infoPlistFile);
 
-        if (infoPlistTags[i].text.includes("FACEBOOK_CLIENT_URLSCHEME")) {
-            infoPlistTags[i].text = infoPlistTags[i].text.replace('FACEBOOK_CLIENT_URLSCHEME', "fb" + facebook_client_appId);
+    const initialCFBundleURLTypeArray = infoPlist['CFBundleURLTypes'];
+    var finalCFBundleURLTypeArray = [];
+    initialCFBundleURLTypeArray.forEach(function(item) {
+        if (item['CFBundleURLName'] == 'Google' && google_url_scheme != '') {
+            item['CFBundleURLSchemes'] = [google_url_scheme];
+            finalCFBundleURLTypeArray.push(item);
+        } else if (item['CFBundleURLName'] == 'Facebook' && facebook_client_appId != '') {
+            item['CFBundleURLSchemes'] = ['fb' + facebook_client_appId];
+            finalCFBundleURLTypeArray.push(item);
+        } else if (item['CFBundleURLName'] == 'DeepLinkScheme') {
+            item['CFBundleURLSchemes'] = [deeplink_url_scheme];
+            finalCFBundleURLTypeArray.push(item);
         }
+    });
 
-        if (infoPlistTags[i].text.includes("DEEP_LINK_URLSCHEME")) {
-            infoPlistTags[i].text = infoPlistTags[i].text.replace('DEEP_LINK_URLSCHEME', deeplink_url_scheme);
-        }
+    infoPlist['CFBundleURLTypes'] = finalCFBundleURLTypeArray;
+    if (facebook_client_appId != '') {
+        infoPlist['FacebookAppID'] = facebook_client_appId
+    } else {
+        delete infoPlist['FacebookAppID'];
     }
 
-    infoPlistTags = etreeInfoPlist.findall('./dict/string');
-
-    for (var i = 0; i < infoPlistTags.length; i++) {
-        if (infoPlistTags[i].text.includes("FACEBOOK_CLIENT_APPID")) {
-            infoPlistTags[i].text = infoPlistTags[i].text.replace('FACEBOOK_CLIENT_APPID', facebook_client_appId);
-        }
-
-        if (infoPlistTags[i].text.includes("FACEBOOK_CLIENT_TOKEN")) {
-            infoPlistTags[i].text = infoPlistTags[i].text.replace('FACEBOOK_CLIENT_TOKEN', facebook_client_token);
-        }
+    if (facebook_client_token != '') {
+        infoPlist['FacebookClientToken'] = facebook_client_token;
+    } else {
+        delete infoPlist['FacebookClientToken'];
     }
 
-    var resultXmlInfoPlist = etreeInfoPlist.write();
-    fs.writeFileSync(infoPlistPath, resultXmlInfoPlist);
-
+    fs.writeFileSync(infoPlistPath, plist.build(infoPlist, { indent: '\t' }));
 };


### PR DESCRIPTION
## Description
- Fix iOS hook so that providers can be individually configured and not all are required for the plugin to work.
- Improve error handling, so that more detailed messages can be thrown on build process.

3 Builds were generated to test this fix (one with Facebook only, another with Google and final one with both providers):
- https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=2c4030c7332a4f0957146d9a0e78bcba97483633
- https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=fc1a37efde571a9c10fd97386644d835b15bd6ce
- https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=df50f7003530eb09369a78d61445f5add45bf7b2

## Context
This bug was found in the scope of [this JIRA Ticket](https://outsystemsrd.atlassian.net/browse/RMET-1969).

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
