### PR TITLE
RMET-2060 ::: iOS ::: Optional Apple SignIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 2022-12-19
+- Fix: [iOS] Make Apple Sign In optionally, enabling app generation without it (https://outsystemsrd.atlassian.net/browse/RMET-2060).
+
 ## Version 1.0.3 (2022-11-09)
 
 ### 2022-11-08


### PR DESCRIPTION
## Description
Apply fix on hook that checks if Apple SignIn should be included on the plugin or not. This is done by changing the Debug and Release Entitlements files.

Some sample app build was generated to test this fix. Each as a explanation associated:
- App with Apple Sign In Enabled by Default (Capability On on Certificate): https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=1fc95e9c5943c274eeca78258122ed13397ab83c
- App with Apple Sign In Enabled by Configuration (Capability On on Certificate): https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=fbb4f80667ef0766fb2ae05ce41a15dd08477d6d
- App with Apple Sign In Disabled (Capability Off on Certificate): https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=141f5b0aab87642e17f965b3dbc9fdc9e94d16c3

Apps with Apple Sign In Enabled but with Capability Off on Certificate fail while building:
`[2022-12-19T12:25:06.862Z] [ERROR] [b78791521260c40aa5ef49addf0a80b3d20f93ce] [Build] Provisioning profile "Social Login Plugin without Apple Sign In" doesn't support the Sign in with Apple capability. (in target 'Social Login Mobile - Demo' from project 'Social Login Mobile - Demo')`
`[2022-12-19T12:25:06.862Z] [ERROR] [b78791521260c40aa5ef49addf0a80b3d20f93ce] [Build] Provisioning profile "Social Login Plugin without Apple Sign In" doesn't include the com.apple.developer.applesignin entitlement. (in target 'Social Login Mobile - Demo' from project 'Social Login Mobile - Demo')`

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2060

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
