### PR TITLE
RMET-3063 ::: iOS ::: Fix Deep Link Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ The changes documented here do not include those from the original repository.
 
 ## Unreleased
 
-## 2023-10-18
+### 2024-01-22
+- Fix: [iOS] Unable to use `Application ID` as `URL Scheme` when the plugin is installed. 
+
+## Version 2.0.1 (2023-10-24)
+
+### 2023-10-18
 - Fix: Updated facebook-android-sdk version do MABS10 builds work with Facebook login.
 
 ## Version 2.0.0 (2023-03-21)
 
-## 2023-03-20
+### 2023-03-20
 - Feat: Update error code format
 - Feat: [Android] Update error codes and descriptions (https://outsystemsrd.atlassian.net/browse/RMET-2343)
 

--- a/hooks/iOSCopyPreferences.js
+++ b/hooks/iOSCopyPreferences.js
@@ -95,19 +95,25 @@ module.exports = async function (context) {
     const initialCFBundleURLTypeArray = infoPlist['CFBundleURLTypes'];
     var finalCFBundleURLTypeArray = [];
     initialCFBundleURLTypeArray.forEach(function(item) {
-        if (item['CFBundleURLName'] == 'Google' && google_url_scheme != '') {
-            item['CFBundleURLSchemes'] = [google_url_scheme];
-            finalCFBundleURLTypeArray.push(item);
-        } else if (item['CFBundleURLName'] == 'Facebook' && facebook_client_appId != '') {
-            item['CFBundleURLSchemes'] = ['fb' + facebook_client_appId];
-            finalCFBundleURLTypeArray.push(item);
+        if (item['CFBundleURLName'] == 'Google') {
+            if (google_url_scheme != '') {
+                item['CFBundleURLSchemes'] = [google_url_scheme];
+                finalCFBundleURLTypeArray.push(item);
+            }
+        } else if (item['CFBundleURLName'] == 'Facebook') {
+            if (facebook_client_appId != '') {
+                item['CFBundleURLSchemes'] = ['fb' + facebook_client_appId];
+                finalCFBundleURLTypeArray.push(item);
+            }
         } else if (item['CFBundleURLName'] == 'DeepLinkScheme') {
             item['CFBundleURLSchemes'] = [deeplink_url_scheme];
             finalCFBundleURLTypeArray.push(item);
+        } else {
+            finalCFBundleURLTypeArray.push(item);
         }
     });
-
     infoPlist['CFBundleURLTypes'] = finalCFBundleURLTypeArray;
+
     if (facebook_client_appId != '') {
         infoPlist['FacebookAppID'] = facebook_client_appId
     } else {


### PR DESCRIPTION
## Description
Fix the issue with the deep link, where the plugin would replace all `URLType`s with the ones expected by the plugin.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3063

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Tests
Tests were performed manually and are working as expected.

## Screenshots
App's `Info.plist` with Apple Sign-In, Google and LinkedIn configured, showing that the Application ID is still configured as one of the `URL Type`'s.

![image](https://github.com/OutSystems/cordova-outsystems-sociallogins/assets/97543217/a4dbf08c-0d28-4d1c-a17e-5f7e38301ce4)

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
