### PR TITLE
RMET-3139 ::: iOS ::: Fix Deep Link to Specific Screen Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### 2024-01-30
+- Fix: [iOS] Unable for an app to route into the screen mentioned in the deep link (using the `ApplicationID`). (https://outsystemsrd.atlassian.net/browse/RMET-3139)
+
 ## Version 2.0.2 (2024-01-23)
 
 ### 2024-01-22
-- Fix: [iOS] Unable to use `Application ID` as `URL Scheme` when the plugin is installed. 
+- Fix: [iOS] Unable to use `Application ID` as `URL Scheme` when the plugin is installed. (https://outsystemsrd.atlassian.net/browse/RMET-3063)
 
 ## Version 2.0.1 (2023-10-24)
 

--- a/src/ios/AppDelegate+OSSocialLogins.m
+++ b/src/ios/AppDelegate+OSSocialLogins.m
@@ -20,10 +20,27 @@
 }
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-    return [SocialLoginsApplicationDelegate.shared
-            application:app
-            openURL:url
-            options:options];
+    // gets the passed url's `urlScheme`
+    NSString *currentUrlScheme = [url.absoluteString componentsSeparatedByString:@"://"].firstObject;
+    
+    // check if it should delegate to the library or to `CDVAppDelegate`
+    return [self shouldDelegateToLibrary:currentUrlScheme] ? [SocialLoginsApplicationDelegate.shared application:app openURL:url options:options] : [super application:app openURL:url options:options];
+}
+
+- (BOOL)shouldDelegateToLibrary:(NSString *)openURLScheme {
+    // fetch all app's `utlTypes`
+    NSArray *urlTypes = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"];
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id  evaluatedObject, NSDictionary<NSString *,id> * bindings) {
+        // fetch the `urlSchemes` associated to the evaluated `urlType`
+        NSArray * urlSchemeArray = evaluatedObject[@"CFBundleURLSchemes"];
+        // verifies if the `urlType` relates with the `urlScheme` of the to-be-opened URL
+        return [urlSchemeArray containsObject:openURLScheme];
+    }];
+    
+    // applying the filter, it fetches the `urlName` of the matching `urlType`
+    NSString *urlName = [urlTypes filteredArrayUsingPredicate:predicate].firstObject[@"CFBundleURLName"];
+    // checks if the matching `urlName` is one that can be delegated to the library.
+    return [@[@"Google", @"Facebook", @"DeepLinkScheme"] containsObject:urlName];
 }
 
 @end


### PR DESCRIPTION
## Description
Fix the issue with the deep link, where the plugin would not delegate the `ApplicationID` deep link to `CDVAppDelegate`, not making the expected route to the desired screen.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3139

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
Tests were performed manually and are working as expected.

## Screenshots
Using the plugin's Sample App.

https://github.com/OutSystems/cordova-outsystems-sociallogins/assets/97543217/bb70670a-a6f8-4ff9-8f7b-c47f17bff029

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
