### PR TITLE
RMET-4037 ::: iOS ::: Remove `cordova-plugin-add-swift-support` Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### Chores
+- (ios) Replace `cordova-plugin-add-swift-support` plugin with the `SwiftVersion` preference (https://outsystemsrd.atlassian.net/browse/RMET-4037).
+
 ## 2.1.2
 
 ### Fixes
 - Fix: Update dependency to `OSSocialLoginsLib-Android` to use `@SerializableName` annotation to avoid issues when using code obfuscation (https://outsystemsrd.atlassian.net/browse/RMET-3387).
-
 
 ## 2.1.1
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -70,8 +70,7 @@
       <feature name="OSSocialLogins">
         <param name="ios-package" value="OSSocialLogins"/>
       </feature>
-      <preference name="deployment-target" value="13" />
-      <preference name="UseSwiftLanguageVersion" value="5" />
+      <preference name="SwiftVersion" value="5" />
     </config-file>
 
     <config-file target="*-Info.plist" parent="LSApplicationQueriesSchemes">
@@ -99,8 +98,6 @@
     <header-file src="src/ios/AppDelegate+OSSocialLogins.h" />
     <source-file src="src/ios/AppDelegate+OSSocialLogins.m" />
     <framework src="src/ios/frameworks/OSSocialLoginsLib.xcframework" embed="true" custom="true" />
-
-    <dependency id="cordova-plugin-add-swift-support" url="https://github.com/OutSystems/cordova-plugin-add-swift-support.git#2.0.3-OS1"/>
 
     <podspec>
         <config>


### PR DESCRIPTION
## Description
The only thing the plugin needs is the `SwiftVersion`. This is included directly on `plugin.xml`.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-4037

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
