### PR TITLE
fix(android): missing strings.xml on target project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 2.1.4
+
+### Fixes
+- (android) missing strings.xml on target project (https://outsystemsrd.atlassian.net/browse/RMET-4778).
+
 ## 2.1.3
 
 ### Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The changes documented here do not include those from the original repository.
 ## 2.1.4
 
 ### Fixes
-- (android) missing strings.xml on target project (https://outsystemsrd.atlassian.net/browse/RMET-4778).
+- (android) Fixes missing strings.xml on target project (https://outsystemsrd.atlassian.net/browse/RMET-4778).
 
 ## 2.1.3
 

--- a/hooks/androidCopyPreferences.js
+++ b/hooks/androidCopyPreferences.js
@@ -71,23 +71,17 @@ function copyFacebookPreferences(jsonConfig, projectRoot) {
         throw new Error("OUTSYSTEMS_PLUGIN_ERROR: Missing configuration file or error trying to obtain the configuration.");
     }
 
-    let stringsPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/strings.xml');
-    let stringsFile = fs.readFileSync(stringsPath).toString();
-    let etreeStrings = et.parse(stringsFile);
+    // create XML with correct values directly
+    var stringsXmlPath = path.join(projectRoot, 'platforms/android/app/src/main/res/values/os_sociallogins_strings.xml');
 
-    let appIdTags = etreeStrings.findall('./string/[@name="facebook_app_id"]');
-    for (let tag of appIdTags) {
-        tag.text = facebook_client_appId;
-    }
+    const xmlContent = `<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="facebook_app_id">${facebook_client_appId || 'FACEBOOK_SDK_APP_ID'}</string>
+    <string name="facebook_client_token">${facebook_client_token || 'FACEBOOK_SDK_CLIENT_TOKEN'}</string>
+</resources>`;
 
-    let clientTokenTags = etreeStrings.findall('./string/[@name="facebook_client_token"]');
-    for (let tag of clientTokenTags) {
-        tag.text = facebook_client_token;
-    }
-
-    let resultXmlStrings = etreeStrings.write();
-    fs.writeFileSync(stringsPath, resultXmlStrings);
-
+    // write XML file directly
+    fs.writeFileSync(stringsXmlPath, xmlContent);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.sociallogins",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "OutSystems Template for Cordova Plugin",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.plugins.sociallogins" version="2.1.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.sociallogins" version="2.1.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>OSSocialLogins</name>
   <description>OutSystems Template for Cordova Plugin</description>
   <author>OutSystems Inc</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,11 +22,6 @@
 
     </config-file>
     
-   <config-file parent="/*" target="res/values/strings.xml">
-    <string name="facebook_app_id">FACEBOOK_SDK_APP_ID</string>
-    <string name="facebook_client_token">FACEBOOK_SDK_CLIENT_TOKEN</string>
-   </config-file>
-    
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id" />
       <meta-data android:name="com.facebook.sdk.ClientToken" android:value="@string/facebook_client_token" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updated the `androidCopyPreferences` hook to set the strings in a custom `os_sociallogins_strings.xml` file it creates instead of assuming `strings.xml` exists.
- Fixes MABS 12 Cordova builds.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4778

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested with MABS 12 build on O11.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
